### PR TITLE
Update package.json exports for ESM-only build

### DIFF
--- a/.changeset/tender-hornets-relate.md
+++ b/.changeset/tender-hornets-relate.md
@@ -1,0 +1,5 @@
+---
+"@agney/playground": minor
+---
+
+Update the types and exports. The package is ESM only. Fix on latest 1.0 version

--- a/playground/package.json
+++ b/playground/package.json
@@ -23,17 +23,12 @@
     "README.md"
   ],
   "type": "module",
-  "main": "dist/playground.js",
-  "module": "dist/playground.module.js",
+  "main": "dist/Playground.js",
   "types": "dist/Playground.d.ts",
-  "unpkg": "dist/playground.umd.js",
-  "umd:main": "dist/playground.umd.js",
   "exports": {
     ".": {
-      "browser": "./dist/playground.module.js",
-      "umd": "./dist/playground.umd.js",
-      "import": "./dist/playground.module.js",
-      "require": "./dist/playground.js"
+      "types": "./dist/Playground.d.ts",
+      "import": "./dist/Playground.js"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Remove `module`, `unpkg`, `umd:main` fields (no longer generating UMD/CJS bundles)
- Update `main` to point to `dist/Playground.js` (matching actual tsdown output)
- Simplify exports to `types` + `import` conditions only

## Test plan
- [x] Run `pnpm build` and verify dist output
- [ ] Test package import in a consuming project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned playground package to ESM-only distribution
  * Updated module entry points and exports configuration
  * Minor version bump with fixes for version 1.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->